### PR TITLE
ECO-3547: Easycredit payment method address filter

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: '7.1'
+        php: '7.2'
 
     tests:
         override:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
     - MODULE_DIR=module
     - SHOP_DIR=current
     - MODULE_NAME=heidelpay
+    - POSTGRES_PORT=5432
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,10 @@
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
+  "scripts": {
+    "cs-check": "phpcs -p -s --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/",
+    "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/"
+  },
   "extra": {
     "branch-alias": {
       "dev-master": "2.0.x-dev"

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -19,7 +19,7 @@ use SprykerEco\Shared\Heidelpay\HeidelpayConstants;
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_REJECTED_DELIVERY_ADDRESS] = 'Packstation';
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_GRAND_TOTAL_LESS_THAN] = 200;
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_GRAND_TOTAL_MORE_THAN] = 5000;
-$config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE] = 'DE';
+$config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODES] = ['DE'];
 
 // ---------- Merchant config values, got from Heidelpay
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_SECURITY_SENDER] = '';

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -19,6 +19,7 @@ use SprykerEco\Shared\Heidelpay\HeidelpayConstants;
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_REJECTED_DELIVERY_ADDRESS] = 'Packstation';
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_GRAND_TOTAL_LESS_THAN] = 200;
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_GRAND_TOTAL_MORE_THAN] = 5000;
+$config[HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE] = 'DE';
 
 // ---------- Merchant config values, got from Heidelpay
 $config[HeidelpayConstants::CONFIG_HEIDELPAY_SECURITY_SENDER] = '';

--- a/src/SprykerEco/Shared/Heidelpay/HeidelpayConstants.php
+++ b/src/SprykerEco/Shared/Heidelpay/HeidelpayConstants.php
@@ -38,11 +38,11 @@ interface HeidelpayConstants
 
     /**
      * Specification:
-     * - Reject criteria for EasyCredit by country ISO code.
+     * - Reject criteria for EasyCredit by country ISO codes.
      *
      * @api
      */
-    public const CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE = 'HEIDELPAY:CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE';
+    public const CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODES = 'HEIDELPAY:CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODES';
 
     /**
      * Specification:

--- a/src/SprykerEco/Shared/Heidelpay/HeidelpayConstants.php
+++ b/src/SprykerEco/Shared/Heidelpay/HeidelpayConstants.php
@@ -38,6 +38,14 @@ interface HeidelpayConstants
 
     /**
      * Specification:
+     * - Reject criteria for EasyCredit by country ISO code.
+     *
+     * @api
+     */
+    public const CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE = 'HEIDELPAY:CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE';
+
+    /**
+     * Specification:
      * - Security sender configuration.
      *
      * @api

--- a/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
+++ b/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
@@ -58,7 +58,7 @@
     </transfer>
 
     <transfer name="HeidelpayCreditCardPaymentOptions">
-        <property name="optionsList" type="HeidelpayPaymentOption[]" singular="optionsList"/>
+        <property name="optionsList" type="HeidelpayPaymentOption[]" singular="option"/>
         <property name="paymentFrameUrl" type="string"/>
         <property name="lastSuccessfulRegistration" type="HeidelpayCreditCardRegistration"/>
     </transfer>
@@ -132,7 +132,7 @@
     </transfer>
 
     <transfer name="HeidelpayBasketRequest">
-        <property name="items" type="Item[]" singular="items"/>
+        <property name="items" type="Item[]" singular="item"/>
         <property name="totals" type="Totals"/>
         <property name="expenses" type="Expense[]" singular="expense"/>
         <property name="currency" type="Currency"/>
@@ -179,8 +179,8 @@
     </transfer>
 
     <transfer name="HeidelpayResponseConfig">
-        <property name="bankCountries" type="HeidelpayBankCountry[]" singular="bankCountries"/>
-        <property name="bankBrands" type="HeidelpayBank[]" singular="bankBrands"/>
+        <property name="bankCountries" type="HeidelpayBankCountry[]" singular="bankCountry"/>
+        <property name="bankBrands" type="HeidelpayBank[]" singular="bankBrand"/>
     </transfer>
 
     <transfer name="HeidelpayErrorRedirectResponse">
@@ -301,8 +301,8 @@
 
     <transfer name="HeidelpayIdealAuthorizeForm">
         <property name="actionUrl" type="string"/>
-        <property name="countries" type="HeidelpayBankCountry[]" singular="countries"/>
-        <property name="banks" type="HeidelpayBank[]" singular="banks"/>
+        <property name="countries" type="HeidelpayBankCountry[]" singular="country"/>
+        <property name="banks" type="HeidelpayBank[]" singular="bank"/>
     </transfer>
 
     <transfer name="HeidelpayBankCountry">

--- a/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
+++ b/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
@@ -58,7 +58,7 @@
     </transfer>
 
     <transfer name="HeidelpayCreditCardPaymentOptions">
-        <property name="optionsList" type="HeidelpayPaymentOption[]"/>
+        <property name="optionsList" type="HeidelpayPaymentOption[]" singular="optionsList"/>
         <property name="paymentFrameUrl" type="string"/>
         <property name="lastSuccessfulRegistration" type="HeidelpayCreditCardRegistration"/>
     </transfer>
@@ -132,7 +132,7 @@
     </transfer>
 
     <transfer name="HeidelpayBasketRequest">
-        <property name="items" type="Item[]"/>
+        <property name="items" type="Item[]" singular="items"/>
         <property name="totals" type="Totals"/>
         <property name="expenses" type="Expense[]" singular="expense"/>
         <property name="currency" type="Currency"/>
@@ -143,14 +143,14 @@
     </transfer>
 
     <transfer name="HeidelpayExternalPaymentResponse">
-        <property name="body" type="array"/>
+        <property name="body" type="array" singular="body"/>
         <property name="idSalesOrder" type="string"/>
         <property name="applicationSecret" type="string"/>
         <property name="paymentMethod" type="string"/>
     </transfer>
 
     <transfer name="HeidelpayExternalPaymentRequest">
-        <property name="body" type="array"/>
+        <property name="body" type="array" singular="body"/>
     </transfer>
 
     <transfer name="HeidelpayCreditCardInfo">
@@ -179,8 +179,8 @@
     </transfer>
 
     <transfer name="HeidelpayResponseConfig">
-        <property name="bankCountries" type="HeidelpayBankCountry[]"/>
-        <property name="bankBrands" type="HeidelpayBank[]"/>
+        <property name="bankCountries" type="HeidelpayBankCountry[]" singular="bankCountries"/>
+        <property name="bankBrands" type="HeidelpayBank[]" singular="bankBrands"/>
     </transfer>
 
     <transfer name="HeidelpayErrorRedirectResponse">
@@ -233,12 +233,24 @@
 
     <transfer name="Expense">
         <property name="heidelpayItemChannelId" type="string"/>
+        <property name="type" type="string"/>
+        <property name="name" type="string"/>
+        <property name="quantity" type="int"/>
+        <property name="taxRate" type="float"/>
+        <property name="sumDiscountAmountAggregation" type="int"/>
+        <property name="sumPriceToPayAggregation" type="int"/>
+        <property name="sumTaxAmount" type="int"/>
+        <property name="unitPriceToPayAggregation" type="int"/>
     </transfer>
 
     <transfer name="Order">
         <property name="idSalesOrder" type="int"/>
         <property name="heidelpayPayment" type="HeidelpayPayment"/>
         <property name="items" type="Item[]" singular="item"/>
+        <property name="billingAddress" type="Address"/>
+        <property name="email" type="string"/>
+        <property name="totals" type="Totals"/>
+        <property name="customer" type="Customer"/>
     </transfer>
 
     <transfer name="Quote">
@@ -248,6 +260,11 @@
         <property name="totals" type="Totals"/>
         <property name="expenses" type="Expense[]" singular="expense"/>
         <property name="currency" type="Currency"/>
+        <property name="payment" type="Payment" deprecated="Use payments property instead."/>
+        <property name="shippingAddress" type="Address" deprecated="Use item level shipping addresses (item.shipment.shippingAddress) instead."/>
+        <property name="customer" type="Customer"/>
+        <property name="billingAddress" type="Address"/>
+        <property name="orderReference" type="string"/>
     </transfer>
 
     <transfer name="Item">
@@ -261,6 +278,10 @@
         <property name="sku" type="string"/>
         <property name="sumTaxAmountFullAggregation" type="int"/>
         <property name="sumDiscountAmountFullAggregation" type="int"/>
+        <property name="unitPriceToPayAggregation" type="int"/>
+        <property name="sumPriceToPayAggregation" type="int"/>
+        <property name="sumTaxAmount" type="int"/>
+        <property name="idSalesOrderItem" type="int"/>
     </transfer>
 
     <transfer name="Payment">
@@ -273,12 +294,15 @@
         <property name="heidelpayInvoiceSecuredB2c" type="HeidelpayPayment"/>
         <property name="heidelpayDirectDebit" type="HeidelpayDirectDebitPayment"/>
         <property name="idBasket" type="string"/>
+        <property name="paymentMethod" type="string"/>
+        <property name="paymentSelection" type="string"/>
+        <property name="paymentProvider" type="string"/>
     </transfer>
 
     <transfer name="HeidelpayIdealAuthorizeForm">
         <property name="actionUrl" type="string"/>
-        <property name="countries" type="HeidelpayBankCountry[]"/>
-        <property name="banks" type="HeidelpayBank[]"/>
+        <property name="countries" type="HeidelpayBankCountry[]" singular="countries"/>
+        <property name="banks" type="HeidelpayBank[]" singular="banks"/>
     </transfer>
 
     <transfer name="HeidelpayBankCountry">
@@ -335,6 +359,67 @@
         <property name="responseCode" type="string"/>
         <property name="transactionType" type="string"/>
         <property name="heidelpayResponse" type="HeidelpayResponse"/>
+    </transfer>
+
+    <transfer name="Totals">
+        <property name="netTotal" type="int"/>
+        <property name="taxTotal" type="TaxTotal"/>
+        <property name="grandTotal" type="int"/>
+        <property name="hash" type="string"/>
+        <property name="priceToPay" type="int"/>
+    </transfer>
+
+    <transfer name="Currency">
+        <property name="code" type="string"/>
+    </transfer>
+
+    <transfer name="Address">
+        <property name="address1" type="string"/>
+        <property name="address2" type="string"/>
+        <property name="idCustomerAddress" type="int"/>
+        <property name="city" type="string"/>
+        <property name="company" type="string"/>
+        <property name="iso2Code" type="string"/>
+        <property name="firstName" type="string"/>
+        <property name="lastName" type="string"/>
+        <property name="state" type="string"/>
+        <property name="zipCode" type="string"/>
+        <property name="salutation" type="string"/>
+    </transfer>
+
+    <transfer name="Customer">
+        <property name="createdAt" type="string"/>
+        <property name="email" type="string"/>
+        <property name="idCustomer" type="int"/>
+        <property name="isGuest" type="bool"/>
+    </transfer>
+
+    <transfer name="SaveOrder">
+        <property name="idSalesOrder" type="int"/>
+        <property name="orderItems" type="Item[]" singular="orderItem"/>
+    </transfer>
+
+    <transfer name="CheckoutResponse">
+        <property name="isExternalRedirect" type="bool"/>
+        <property name="redirectUrl" type="string"/>
+        <property name="saveOrder" type="SaveOrder"/>
+        <property name="isSuccess" type="bool"/>
+    </transfer>
+
+    <transfer name="PaymentMethods">
+        <property name="methods" singular="method" type="PaymentMethod[]"/>
+    </transfer>
+
+    <transfer name="PaymentMethod">
+        <property name="methodName" type="string"/>
+    </transfer>
+
+    <transfer name="OrderList">
+        <property name="orders" type="Order[]" singular="order"/>
+    </transfer>
+
+    <transfer name="TaxTotal">
+        <property name="amount" type="int"/>
     </transfer>
 
 </transfers>

--- a/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
+++ b/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
@@ -385,6 +385,7 @@
         <property name="state" type="string"/>
         <property name="zipCode" type="string"/>
         <property name="salutation" type="string"/>
+        <property name="isDefaultBilling" type="bool"/>
     </transfer>
 
     <transfer name="Customer">

--- a/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
+++ b/src/SprykerEco/Shared/Heidelpay/Transfer/heidelpay.transfer.xml
@@ -386,6 +386,7 @@
         <property name="zipCode" type="string"/>
         <property name="salutation" type="string"/>
         <property name="isDefaultBilling" type="bool"/>
+        <property name="isDefaultShipping" type="bool"/>
     </transfer>
 
     <transfer name="Customer">

--- a/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
+++ b/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
@@ -54,7 +54,7 @@ class PaymentMethodFilter implements PaymentMethodFilterInterface
         $result = new ArrayObject();
 
         foreach ($paymentMethodsTransfer->getMethods() as $paymentMethod) {
-            if ($this->isPaymentMethodHeidelpayEasyCredit($paymentMethod) && !$this->isQuoteValidForEasyCredit($quoteTransfer)) {
+            if ($this->isPaymentMethodHeidelpayEasyCredit($paymentMethod) && !$this->isEasyCreditAllowed($quoteTransfer)) {
                 continue;
             }
 
@@ -81,7 +81,7 @@ class PaymentMethodFilter implements PaymentMethodFilterInterface
      *
      * @return bool
      */
-    protected function isQuoteValidForEasyCredit(QuoteTransfer $quoteTransfer): bool
+    protected function isEasyCreditAllowed(QuoteTransfer $quoteTransfer): bool
     {
         $billingAddressData = $quoteTransfer->getBillingAddress()->toArrayRecursiveCamelCased();
         $shippingAddressData = $quoteTransfer->getShippingAddress()->toArrayRecursiveCamelCased();
@@ -92,7 +92,7 @@ class PaymentMethodFilter implements PaymentMethodFilterInterface
             $shippingAddressData[AddressTransfer::IS_DEFAULT_SHIPPING]
         );
 
-        return in_array($quoteTransfer->getShippingAddress()->getIso2Code(), $this->config->getEasycreditCriteriaCountryIsoCodes(), true)
+        return in_array($quoteTransfer->getShippingAddress()->getIso2Code(), $this->config->getEasyCreditAllowedCountries(), true)
             && $this->isAddressCorrect($quoteTransfer)
             && $billingAddressData === $shippingAddressData
             && !$this->isQuoteGrandTotalOutOfRange($quoteTransfer);

--- a/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
+++ b/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
@@ -8,6 +8,7 @@
 namespace SprykerEco\Zed\Heidelpay\Business\Payment;
 
 use ArrayObject;
+use Generated\Shared\Transfer\AddressTransfer;
 use Generated\Shared\Transfer\PaymentMethodsTransfer;
 use Generated\Shared\Transfer\PaymentMethodTransfer;
 use Generated\Shared\Transfer\QuoteTransfer;
@@ -82,9 +83,18 @@ class PaymentMethodFilter implements PaymentMethodFilterInterface
      */
     protected function isQuoteValidForEasyCredit(QuoteTransfer $quoteTransfer): bool
     {
+        $billingAddressData = $quoteTransfer->getBillingAddress()->toArrayRecursiveCamelCased();
+        $shippingAddressData = $quoteTransfer->getShippingAddress()->toArrayRecursiveCamelCased();
+        unset(
+            $billingAddressData[AddressTransfer::IS_DEFAULT_BILLING],
+            $shippingAddressData[AddressTransfer::IS_DEFAULT_BILLING],
+            $billingAddressData[AddressTransfer::IS_DEFAULT_SHIPPING],
+            $shippingAddressData[AddressTransfer::IS_DEFAULT_SHIPPING]
+        );
+
         return in_array($quoteTransfer->getShippingAddress()->getIso2Code(), $this->config->getEasycreditCriteriaCountryIsoCodes(), true)
             && $this->isAddressCorrect($quoteTransfer)
-            && $quoteTransfer->getBillingAddress()->toArray() === $quoteTransfer->getShippingAddress()->toArray()
+            && $billingAddressData === $shippingAddressData
             && !$this->isQuoteGrandTotalOutOfRange($quoteTransfer);
     }
 

--- a/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
+++ b/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
@@ -17,8 +17,6 @@ use SprykerEco\Zed\Heidelpay\HeidelpayConfig;
 
 class PaymentMethodFilter implements PaymentMethodFilterInterface
 {
-    protected const ISO2_COUNTRY_DE = 'DE';
-
     /**
      * @var \SprykerEco\Zed\Heidelpay\HeidelpayConfig
      */
@@ -84,7 +82,7 @@ class PaymentMethodFilter implements PaymentMethodFilterInterface
      */
     protected function isQuoteValidForEasyCredit(QuoteTransfer $quoteTransfer): bool
     {
-        return $quoteTransfer->getShippingAddress()->getIso2Code() === static::ISO2_COUNTRY_DE
+        return $quoteTransfer->getShippingAddress()->getIso2Code() === $this->config->getEasycreditCriteriaCountryIsoCode()
             && $this->isAddressCorrect($quoteTransfer)
             && $quoteTransfer->getBillingAddress()->toArray() === $quoteTransfer->getShippingAddress()->toArray()
             && !$this->isQuoteGrandTotalOutOfRange($quoteTransfer);

--- a/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
+++ b/src/SprykerEco/Zed/Heidelpay/Business/Payment/PaymentMethodFilter.php
@@ -82,7 +82,7 @@ class PaymentMethodFilter implements PaymentMethodFilterInterface
      */
     protected function isQuoteValidForEasyCredit(QuoteTransfer $quoteTransfer): bool
     {
-        return $quoteTransfer->getShippingAddress()->getIso2Code() === $this->config->getEasycreditCriteriaCountryIsoCode()
+        return in_array($quoteTransfer->getShippingAddress()->getIso2Code(), $this->config->getEasycreditCriteriaCountryIsoCodes(), true)
             && $this->isAddressCorrect($quoteTransfer)
             && $quoteTransfer->getBillingAddress()->toArray() === $quoteTransfer->getShippingAddress()->toArray()
             && !$this->isQuoteGrandTotalOutOfRange($quoteTransfer);

--- a/src/SprykerEco/Zed/Heidelpay/HeidelpayConfig.php
+++ b/src/SprykerEco/Zed/Heidelpay/HeidelpayConfig.php
@@ -181,7 +181,7 @@ class HeidelpayConfig extends AbstractBundleConfig implements HeidelpayConfigInt
     /**
      * @return string[]
      */
-    public function getEasycreditCriteriaCountryIsoCodes(): array
+    public function getEasyCreditAllowedCountries(): array
     {
         return $this->get(HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODES, ['DE']);
     }

--- a/src/SprykerEco/Zed/Heidelpay/HeidelpayConfig.php
+++ b/src/SprykerEco/Zed/Heidelpay/HeidelpayConfig.php
@@ -179,11 +179,11 @@ class HeidelpayConfig extends AbstractBundleConfig implements HeidelpayConfigInt
     }
 
     /**
-     * @return float
+     * @return string[]
      */
-    public function getEasycreditCriteriaCountryIsoCode(): string
+    public function getEasycreditCriteriaCountryIsoCodes(): array
     {
-        return $this->get(HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE);
+        return $this->get(HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODES, ['DE']);
     }
 
     /**

--- a/src/SprykerEco/Zed/Heidelpay/HeidelpayConfig.php
+++ b/src/SprykerEco/Zed/Heidelpay/HeidelpayConfig.php
@@ -179,6 +179,14 @@ class HeidelpayConfig extends AbstractBundleConfig implements HeidelpayConfigInt
     }
 
     /**
+     * @return float
+     */
+    public function getEasycreditCriteriaCountryIsoCode(): string
+    {
+        return $this->get(HeidelpayConstants::CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODE);
+    }
+
+    /**
      * @return bool
      */
     public function getIsSplitPaymentEnabledKey(): bool


### PR DESCRIPTION
- Developer(s): @denis-gnusov

- Ticket: https://spryker.atlassian.net/browse/ECO-3547


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Heidelpay             | minor                 |                       |

-----------------------------------------

#### Module Heidelpay

##### Change log

Improvements

- Adjusted `HeidelpayFacade::filterPaymentMethods()` to filter out EasyCredit method if billing address is not the same as shipping address.
- Impacted `HeidelpayPaymentMethodFilterPlugin` with facade changes.
- Introduced `HEIDELPAY:CONFIG_HEIDELPAY_EASYCREDIT_CRITERIA_COUNTRY_ISO_CODES` environment config to set allowed counties for EasyCredit payment method.


